### PR TITLE
Adding source first parent view

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,15 @@
   "activationEvents": [],
   "main": "./out/extension.js",
   "contributes": {
+    "views": {
+      "scm": [
+        {
+          "icon": "",
+          "id": "reviews.firstParentGraph",
+          "name": "First-Parent Graph"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "reviews.compare",
@@ -25,8 +34,39 @@
       {
         "command": "reviews.reset",
         "title": "reviews: Reset branch"
+      },
+      {
+        "command": "reviews.firstParentGraph.refresh",
+        "title": "reviews: Refresh First-Parent Graph"
+      },
+      {
+        "command": "reviews.firstParentGraph.copySha",
+        "title": "review: Copy Commit SHA"
+      },
+      {
+        "command": "reviews.firstParentGraph.showCommit",
+        "title": "reviews: Show Commit (git show)"
       }
-    ]
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "reviews.firstParentGraph.refresh",
+          "when": "view == reviews.firstParentGraph",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "reviews.firstParentGraph.copySha",
+          "when": "view == reviews.firstParentGraph"
+        },
+        {
+          "command": "reviews.firstParentGraph.showCommit",
+          "when": "view == reviews.firstParentGraph"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
@@ -47,5 +87,8 @@
     "eslint": "^8.54.0",
     "prettier": "^2.4.1",
     "typescript": "^5.3.2"
-  }
+  },
+  "extensionDependencies": [
+    "vscode.git"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
       },
       {
         "command": "reviews.firstParentGraph.toggleOnlyBranchCommits",
-        "title": "Toggle: Only Commits Not On Base"
+        "title": "Toggle: Only Commits Not On Base",
+        "when": "false"
       },
       {
         "command": "reviews.firstParentGraph.refresh",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,20 @@
   "activationEvents": [],
   "main": "./out/extension.js",
   "contributes": {
+    "configuration": {
+      "properties": {
+        "firstParentGraph.baseBranch": {
+          "type": "string",
+          "default": "auto",
+          "description": "Base branch to compare against (e.g., 'main', 'origin/main'). 'auto' tries origin/HEAD → origin/main → main → origin/master → master."
+        },
+        "firstParentGraph.onlyBranchCommitsByDefault": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show only commits not on the base branch by default."
+        }
+      }
+    },
     "views": {
       "scm": [
         {
@@ -34,6 +48,10 @@
       {
         "command": "reviews.reset",
         "title": "reviews: Reset branch"
+      },
+      {
+        "command": "reviews.firstParentGraph.toggleOnlyBranchCommits",
+        "title": "Toggle: Only Commits Not On Base"
       },
       {
         "command": "reviews.firstParentGraph.refresh",
@@ -54,9 +72,9 @@
     "menus": {
       "view/title": [
         {
-          "command": "reviews.firstParentGraph.refresh",
+          "command": "reviews.firstParentGraph.toggleOnlyBranchCommits",
           "when": "view == reviews.firstParentGraph",
-          "group": "navigation"
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -37,15 +37,18 @@
       },
       {
         "command": "reviews.firstParentGraph.refresh",
-        "title": "reviews: Refresh First-Parent Graph"
+        "title": "Refresh First-Parent Graph",
+        "when": "false"
       },
       {
         "command": "reviews.firstParentGraph.copySha",
-        "title": "review: Copy Commit SHA"
+        "title": "Copy Commit SHA",
+        "when": "false"
       },
       {
         "command": "reviews.firstParentGraph.showCommit",
-        "title": "reviews: Show Commit (git show)"
+        "title": "Show Commit (git show)",
+        "when": "false"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -51,23 +51,19 @@
       },
       {
         "command": "reviews.firstParentGraph.toggleOnlyBranchCommits",
-        "title": "Toggle: Only Commits Not On Base",
-        "when": "false"
+        "title": "Toggle: Only Commits Not On Base"
       },
       {
         "command": "reviews.firstParentGraph.refresh",
-        "title": "Refresh First-Parent Graph",
-        "when": "false"
+        "title": "Refresh First-Parent Graph"
       },
       {
         "command": "reviews.firstParentGraph.copySha",
-        "title": "Copy Commit SHA",
-        "when": "false"
+        "title": "Copy Commit SHA"
       },
       {
         "command": "reviews.firstParentGraph.showCommit",
-        "title": "Show Commit (git show)",
-        "when": "false"
+        "title": "Show Commit (git show)"
       }
     ],
     "menus": {
@@ -86,6 +82,24 @@
         {
           "command": "reviews.firstParentGraph.showCommit",
           "when": "view == reviews.firstParentGraph"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "reviews.firstParentGraph.toggleOnlyBranchCommits",
+          "when": "false"
+        },
+        {
+          "command": "reviews.firstParentGraph.refresh",
+          "when": "false"
+        },
+        {
+          "command": "reviews.firstParentGraph.copySha",
+          "when": "false"
+        },
+        {
+          "command": "reviews.firstParentGraph.showCommit",
+          "when": "false"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -241,6 +241,15 @@ export async function activate(context: vscode.ExtensionContext) {
           vscode.window.showErrorMessage(`git show failed: ${e?.message ?? e}`);
         }
       }
+    ),
+    vscode.commands.registerCommand(
+      "reviews.firstParentGraph.toggleOnlyBranchCommits",
+      async () => {
+        provider["onlyBranch"] = !provider["onlyBranch"];
+        const mode = provider["onlyBranch"] ? "ON" : "OFF";
+        vscode.window.setStatusBarMessage(`Only-branch filter: ${mode}`, 2000);
+        await provider.refresh();
+      }
     )
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -245,8 +245,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       "reviews.firstParentGraph.toggleOnlyBranchCommits",
       async () => {
-        provider["onlyBranch"] = !provider["onlyBranch"];
-        const mode = provider["onlyBranch"] ? "ON" : "OFF";
+        const mode = provider.toggleOnlyBranch() ? "ON" : "OFF";
         vscode.window.setStatusBarMessage(`Only-branch filter: ${mode}`, 2000);
         await provider.refresh();
       }

--- a/src/firstParentGraph.ts
+++ b/src/firstParentGraph.ts
@@ -1,0 +1,183 @@
+import * as vscode from "vscode";
+import { execFile } from "child_process";
+import * as path from "path";
+import * as fs from "fs";
+
+type Maybe<T> = T | undefined;
+
+interface CommitItem {
+  sha: string;
+  subject: string;
+  author: string;
+  date: string; // iso
+  parents: string[]; // length > 1 => merge commit
+}
+
+/** Picks a repo root directory, preferring the built-in Git extension if present. */
+export async function pickRepositoryRoot(): Promise<string | undefined> {
+  // Prefer the built-in Git extension (if available)
+  try {
+    const gitExt = vscode.extensions.getExtension<any>("vscode.git");
+    await gitExt?.activate();
+    const api = gitExt?.exports?.getAPI?.(1);
+    const repo = api?.repositories?.[0];
+    if (repo?.rootUri?.fsPath) return repo.rootUri.fsPath;
+  } catch {
+    // ignore and fall back to heuristic
+  }
+
+  // Fallback: find a .git folder starting from the first workspace folder
+  const ws = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  if (!ws) return undefined;
+
+  // Walk up the tree to find .git
+  let dir = ws;
+  while (true) {
+    if (fs.existsSync(path.join(dir, ".git"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}
+
+/** Simple watcher for .git/HEAD changes to refresh the view. */
+export function headFileWatcher(
+  repoRoot: Maybe<string>,
+  onChange: () => void
+): vscode.FileSystemWatcher | { dispose(): void } {
+  if (!repoRoot) return { dispose() {} };
+  const headUri = vscode.Uri.file(path.join(repoRoot, ".git", "HEAD"));
+  // Watch both HEAD and refs, as HEAD may be a symbolic ref
+  const watcher = vscode.workspace.createFileSystemWatcher(
+    new vscode.RelativePattern(path.join(repoRoot, ".git"), "**/*")
+  );
+  watcher.onDidChange((uri) => {
+    if (
+      uri.fsPath === headUri.fsPath ||
+      uri.fsPath.includes(path.sep + "refs" + path.sep)
+    )
+      onChange();
+  });
+  watcher.onDidCreate(onChange);
+  watcher.onDidDelete(onChange);
+  return watcher;
+}
+
+/** Tree Data Provider */
+export class FirstParentProvider
+  implements vscode.TreeDataProvider<CommitTreeItem>
+{
+  private _onDidChangeTreeData = new vscode.EventEmitter<
+    CommitTreeItem | undefined | void
+  >();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private commits: CommitItem[] = [];
+  constructor(public readonly repoRoot?: string) {}
+
+  refresh() {
+    this.load().finally(() => this._onDidChangeTreeData.fire());
+  }
+
+  async load() {
+    if (!this.repoRoot) {
+      this.commits = [];
+      return;
+    }
+    try {
+      // --first-parent folds other-parent history by design; we still see the merge commit.
+      // Using ASCII unit separators for robust parsing.
+      const format = ["%H", "%P", "%s", "%an", "%ad"].join("%x1f") + "%x1e";
+      const out = await execGit(
+        [
+          "log",
+          "--first-parent",
+          "--max-count=300",
+          `--pretty=format:${format}`,
+          "--date=iso",
+        ],
+        this.repoRoot
+      );
+      this.commits = parseLog(out);
+    } catch (e: any) {
+      vscode.window.showErrorMessage(
+        `Failed to read git log: ${e?.message ?? e}`
+      );
+      this.commits = [];
+    }
+  }
+
+  getTreeItem(element: CommitTreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: CommitTreeItem): Thenable<CommitTreeItem[]> {
+    if (element) return Promise.resolve([]);
+    const items = this.commits.map((c) => {
+      const isMerge = c.parents.length > 1;
+      const label = `${c.subject}`;
+      const description = `${c.author} — ${new Date(c.date).toLocaleString()}`;
+      const item = new CommitTreeItem(label, description, c);
+      item.iconPath = new vscode.ThemeIcon(
+        isMerge ? "git-merge" : "git-commit"
+      );
+      item.tooltip = [
+        `$(git-commit) ${c.sha}`,
+        isMerge
+          ? `$(git-merge) Merge commit (parents: ${c.parents.length})`
+          : `Parent(s): ${c.parents.length}`,
+        `Author: ${c.author}`,
+        `Date: ${c.date}`,
+      ].join("\n");
+      item.command = {
+        command: "reviews.firstParentGraph.showCommit",
+        title: "Show Commit",
+        arguments: [item],
+      };
+      return item;
+    });
+    return Promise.resolve(items);
+  }
+}
+
+export class CommitTreeItem extends vscode.TreeItem {
+  constructor(
+    label: string,
+    description: string,
+    public readonly commit: CommitItem
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.description = description;
+    this.contextValue = "firstParentCommit";
+  }
+}
+
+/** Exec git and return stdout as string. */
+export function execGit(args: string[], cwd?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = execFile("git", args, { cwd }, (err, stdout, stderr) => {
+      if (err) return reject(new Error(stderr || err.message));
+      resolve(stdout);
+    });
+    // Just in case: kill long-running in odd environments
+    setTimeout(() => {
+      try {
+        child.kill();
+      } catch {}
+    }, 20000);
+  });
+}
+
+/** Parse custom-delimited git log output. */
+export function parseLog(raw: string): CommitItem[] {
+  const records = raw
+    .split("\x1e")
+    .map((r) => r.trim())
+    .filter(Boolean);
+  return records.map((rec) => {
+    const [h, p, s, an, ad] = rec.split("\x1f");
+    const parents = (p || "").trim() ? p.trim().split(/\s+/) : [];
+    return { sha: h, subject: s, author: an, date: ad, parents };
+  });
+}

--- a/src/firstParentGraph.ts
+++ b/src/firstParentGraph.ts
@@ -244,16 +244,14 @@ export class FirstParentProvider
         ).trim();
         if (!mergeBase) continue;
 
-        // Walk commits along the ancestry path from the merge-base to the non-first parent
-        const fmt = ["%H", "%P", "%s", "%an", "%ad"].join("%x1f") + "%x1e";
+        // Walk commits from the merge-base to the non-first parent
+        const format = ["%H", "%P", "%s", "%an", "%cr"].join("%x1f") + "%x1e";
         const out = await execGit(
           [
             "log",
-            "--pretty=format:" + fmt,
-            "--date=iso",
             "--topo-order",
-            "--ancestry-path",
-            "--reverse",
+            "--max-count=300",
+            `--pretty=format:${format}`,
             `${mergeBase}..${parent}`,
           ],
           this.repoRoot
@@ -360,7 +358,7 @@ async function inferBaseRef(cwd?: string): Promise<string | undefined> {
     ).trim();
     if (head && (await refExists(head, cwd))) return head;
   } catch {
-    return "main";
+    console.error("Couldn't find the repob base branch ! defaultinf on 'main'");
   }
 
   // 2) Common fallbacks

--- a/src/firstParentGraph.ts
+++ b/src/firstParentGraph.ts
@@ -87,6 +87,11 @@ export class FirstParentProvider
 
   constructor(public readonly repoRoot?: string) {}
 
+  public toggleOnlyBranch(): boolean {
+    this.onlyBranch = !this.onlyBranch;
+    return this.onlyBranch;
+  }
+
   async refresh() {
     this.foldedCache.clear();
     await this.load();
@@ -312,16 +317,15 @@ class FoldedCommitItem extends vscode.TreeItem {
 /** Exec git and return stdout as string. */
 export function execGit(args: string[], cwd?: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const child = execFile("git", args, { cwd }, (err, stdout, stderr) => {
-      if (err) return reject(new Error(stderr || err.message));
-      resolve(stdout);
-    });
-    // Just in case: kill long-running in odd environments
-    setTimeout(() => {
-      try {
-        child.kill();
-      } catch {}
-    }, 20000);
+    const child = execFile(
+      "git",
+      args,
+      { cwd, timeout: 20000, maxBuffer: 10 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) return reject(new Error(stderr || err.message));
+        resolve(stdout);
+      }
+    );
   });
 }
 

--- a/src/firstParentGraph.ts
+++ b/src/firstParentGraph.ts
@@ -358,7 +358,7 @@ async function inferBaseRef(cwd?: string): Promise<string | undefined> {
     ).trim();
     if (head && (await refExists(head, cwd))) return head;
   } catch {
-    console.error("Couldn't find the repob base branch ! defaultinf on 'main'");
+    console.error("Couldn't find the repo base branch ! defaulting on 'main'");
   }
 
   // 2) Common fallbacks

--- a/src/firstParentGraph.ts
+++ b/src/firstParentGraph.ts
@@ -88,14 +88,13 @@ export class FirstParentProvider
     try {
       // --first-parent folds other-parent history by design; we still see the merge commit.
       // Using ASCII unit separators for robust parsing.
-      const format = ["%H", "%P", "%s", "%an", "%ad"].join("%x1f") + "%x1e";
+      const format = ["%H", "%P", "%s", "%an", "%cr"].join("%x1f") + "%x1e";
       const out = await execGit(
         [
           "log",
           "--first-parent",
           "--max-count=300",
           `--pretty=format:${format}`,
-          "--date=iso",
         ],
         this.repoRoot
       );
@@ -117,7 +116,7 @@ export class FirstParentProvider
     const items = this.commits.map((c) => {
       const isMerge = c.parents.length > 1;
       const label = `${c.subject}`;
-      const description = `${c.author} — ${new Date(c.date).toLocaleString()}`;
+      const description = `${c.author} — ${c.date}`;
       const item = new CommitTreeItem(label, description, c);
       item.iconPath = new vscode.ThemeIcon(
         isMerge ? "git-merge" : "git-commit"
@@ -176,8 +175,8 @@ export function parseLog(raw: string): CommitItem[] {
     .map((r) => r.trim())
     .filter(Boolean);
   return records.map((rec) => {
-    const [h, p, s, an, ad] = rec.split("\x1f");
+    const [h, p, s, an, cr] = rec.split("\x1f");
     const parents = (p || "").trim() ? p.trim().split(/\s+/) : [];
-    return { sha: h, subject: s, author: an, date: ad, parents };
+    return { sha: h, subject: s, author: an, date: cr, parents };
   });
 }

--- a/src/firstParentGraph.ts
+++ b/src/firstParentGraph.ts
@@ -317,7 +317,7 @@ class FoldedCommitItem extends vscode.TreeItem {
 /** Exec git and return stdout as string. */
 export function execGit(args: string[], cwd?: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const child = execFile(
+    execFile(
       "git",
       args,
       { cwd, timeout: 20000, maxBuffer: 10 * 1024 * 1024 },


### PR DESCRIPTION
@QGarchery I introduce a First-Parent Graph view in the Source Control tab. This view shows the list of commits from the current branch (the first parent) and also, the commits from the other parents **but folded**. This is particularly useful if lots of commits happened on the base branch.

### 2 examples

1) Rather simple git history (current branch is `develop` - previously named 'merge-feature'):
<img width="693" height="632" alt="image" src="https://github.com/user-attachments/assets/da51a337-93c1-4510-bb9e-ff6c6c7c62f5" />


2) Lots of commits from the other branches (current branch is `develop`). In real life scenarios, there can be many more commits, hidding prior commits you made on your branch:
<img width="677" height="784" alt="image" src="https://github.com/user-attachments/assets/e5df4790-f421-4739-8cbf-ccb5fff9597a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a First-Parent Graph view in Source Control to explore branch history with collapsible merges, auto-refresh on HEAD changes, and commands to refresh, copy commit SHA, toggle "Only commits not on base", and show commit diffs with status/error feedback.

* **Configuration**
  * New settings: firstParentGraph.baseBranch (default "auto") and firstParentGraph.onlyBranchCommitsByDefault (default true).

* **Chores**
  * Declares dependency on the Git extension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->